### PR TITLE
feat: add OpenClaw agent skill for meteora-invent

### DIFF
--- a/skills/meteora-launch/SKILL.md
+++ b/skills/meteora-launch/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: meteora-launch
+description: "Launch tokens and manage liquidity on Meteora (Solana DeFi). Use for: creating token bonding curves (DBC), setting up AMM pools (DAMM v1/v2), concentrated liquidity pools (DLMM), alpha vaults, presale vaults, adding/removing liquidity, claiming fees, and token migrations. Triggers on: Meteora protocol operations, Solana token launches, DeFi pool creation, liquidity management, bonding curve setup, and any meteora-invent CLI usage."
+metadata: {"openclaw": {"emoji": "🌊", "homepage": "https://github.com/MeteoraAg/meteora-invent"}}
+---
+
+# Meteora Launch
+
+Automate token launches and liquidity operations on Meteora using the [meteora-invent](https://github.com/MeteoraAg/meteora-invent) CLI toolkit.
+
+> **Already inside meteora-invent?** Run `pnpm install` and configure `studio/.env`. New? See `references/setup.md`.
+
+## Quick Start
+
+```bash
+# 1. Set up environment
+cd <your-meteora-invent-dir>
+cp studio/.env.example studio/.env
+# Edit .env: PAYER_PRIVATE_KEY + RPC_URL
+
+# 2. Install deps
+pnpm install
+
+# 3. Generate keypair (devnet includes 5 SOL airdrop)
+pnpm studio generate-keypair --network devnet --airdrop
+```
+
+## Protocol Selection
+
+| Goal | Protocol | Command prefix |
+|---|---|---|
+| New token launch | **DBC** | `dbc-*` |
+| Standard AMM + yield | **DAMM v1** | `damm-v1-*` |
+| Advanced AMM | **DAMM v2** | `damm-v2-*` |
+| Concentrated liquidity | **DLMM** | `dlmm-*` |
+| Yield strategies | **Alpha Vault** | `alpha-vault-*` |
+| Token presale | **Presale Vault** | `presale-vault-*` |
+
+## Core Workflows
+
+### Full Token Launch (DBC → DAMM v2)
+
+```bash
+# 1. Create config account
+pnpm studio dbc-create-config
+
+# 2. Launch bonding curve + mint
+pnpm studio dbc-create-pool
+
+# 3. Users trade until quoteReserve > migrationQuoteThreshold
+
+# 4. Migrate to AMM
+pnpm studio dbc-migrate-to-damm-v2 --baseMint <MINT>
+```
+
+### DLMM + Alpha Vault
+
+```bash
+pnpm studio dlmm-create-pool --baseMint <MINT>
+pnpm studio dlmm-seed-liquidity-lfg --baseMint <MINT>
+pnpm studio alpha-vault-create --baseMint <MINT>
+```
+
+### DAMM v2 Pool
+
+```bash
+pnpm studio damm-v2-create-balanced-pool --baseMint <MINT>
+pnpm studio damm-v2-add-liquidity --poolAddress <POOL>
+pnpm studio damm-v2-claim-position-fee --poolAddress <POOL>
+```
+
+## Universal Config Fields
+
+All protocols share these base fields in `studio/config/*.jsonc`:
+
+```jsonc
+{
+  "rpcUrl": "https://api.mainnet-beta.solana.com",  // or devnet
+  "dryRun": false,        // true = simulate only (always test first)
+  "keypairFilePath": "./keypair.json",
+  "computeUnitPriceMicroLamports": 100000,
+  "quoteMint": "So11111111111111111111111111111111111111112"  // SOL
+}
+```
+
+## Safety
+
+- **Always devnet first:** set `"rpcUrl": "https://api.devnet.solana.com"`
+- **Always dry-run first:** set `"dryRun": true` before executing
+- Verify all addresses on [explorer.solana.com](https://explorer.solana.com)
+- Minimum SOL: ~0.05 for pool creation, ~0.1 recommended
+
+## Troubleshooting
+
+| Error | Fix |
+|---|---|
+| `Configuration validation failed` | Check JSONC syntax, verify all required fields |
+| `Insufficient SOL balance` | Add SOL or use devnet airdrop |
+| `Transaction simulation failed` | Check RPC, verify mint exists on network |
+| `RPC connection failed` | Test endpoint, try premium provider (Helius, QuickNode) |
+
+## References
+
+- **`references/actions.md`** — All 27 actions with full flags, config fields, and outputs
+- **`references/LLM.txt`** — Comprehensive automation guide, all parameters, validation checklists
+- **`references/example_dbc_config.jsonc`** — Ready-to-use DBC config template
+- **`references/setup.md`** — Toolkit installation and environment setup
+
+## Verification
+
+- Solana Explorer: `https://explorer.solana.com/`
+- Meteora App: `https://app.meteora.ag/`
+- DexScreener: `https://dexscreener.com/solana/`

--- a/skills/meteora-launch/references/LLM.txt
+++ b/skills/meteora-launch/references/LLM.txt
@@ -1,0 +1,290 @@
+# LLM.txt - Meteora Invent Repository
+
+**AI-Optimized Monorepo for Solana DeFi Operations with Meteora**
+
+## 🎯 Quick AI Context
+
+Meteora Invent is a comprehensive toolkit consisting of everything you need to invent innovative token launches on Meteora. Meet **Metsumi**, your personal launch assistant engineered to help you launch anything and do any action on Meteora programs with just a few configurations and CLI commands.
+
+### Core Components:
+- **Studio**: Scripts for doing any action on Meteora programs
+- **Scaffolds**: Production-ready frontend application templates compatible with Meteora's Dynamic Bonding Curve program.
+- **Shared Packages**: Reusable configurations, utilities, and TypeScript settings
+
+**AI Navigation**: Follow the hierarchical LLM.txt structure → Each directory contains specific AI guidance
+
+## 📊 Repository Architecture
+
+### **Core Workspaces**
+- **`studio/`** → **Scripts Operations**: Meteora program actions, config-driven automation for Meteora programs
+- **`scaffolds/`** → **Frontend Templates**: Production-ready UI applications
+- **`packages/`** → **Shared Code**: ESLint, Prettier, TypeScript configs, and utility functions
+
+### **AI-Friendly Design**
+- ✅ **Hierarchical LLM.txt**: Detailed guidance at every level
+- ✅ **Config-Driven**: All parameters externalized to JSONC files
+- ✅ **Safe Execution**: Built-in dry-run and validation modes
+- ✅ **Clear Boundaries**: Explicit files AI can/cannot modify
+- ✅ **Metsumi**: (coming soon)
+
+## 🚀 Global Setup & Prerequisites
+
+### **System Requirements**
+- **Node.js** >= 18.0.0
+- **pnpm** >= 10.0.0 (package manager)
+- **Solana wallet** with SOL balance
+- **RPC endpoint** (recommended: Helius, QuickNode, or similar)
+
+### **Initial Repository Setup**
+```bash
+# 1. Clone repository
+git clone https://github.com/MeteoraAg/meteora-invent.git
+cd meteora-invent
+
+# 2. Install all dependencies (handles workspaces automatically)
+pnpm install
+
+# 3. Build all packages (creates shared libraries)
+pnpm build
+
+# 4. Validate environment (optional but recommended)
+pnpm validate-env
+```
+
+### **Environment Configuration Pattern**
+Each workspace follows this pattern:
+```bash
+# Navigate to workspace
+cd studio/  # or scaffolds/fun-launch/, etc.
+
+# Copy environment template
+cp .env.example .env
+
+# Edit with your settings
+# - RPC_URL=your_rpc_endpoint
+# - PAYER_PRIVATE_KEY=your_wallet_private_key
+# - Other workspace-specific variables
+```
+
+## 🗺️ AI Navigation Map
+
+### **🎯 Task-Based Navigation**
+
+| **Goal** | **Navigate To** | **Purpose** |
+|----------|----------------|-------------|
+| Launch new token | `studio/LLM.txt` → DBC section | Token deployment with bonding curve |
+| Create AMM pools | `studio/LLM.txt` → DAMM V2 section | Liquidity pool creation |
+| Concentrated liquidity | `studio/LLM.txt` → DLMM section | Advanced position management |
+| Build trading UI | `scaffolds/fun-launch/LLM.txt` | Complete frontend application |
+| Migrate DBC→AMM | `studio/LLM.txt` → Migration workflows | Pool graduation process |
+| Configure shared tools | `packages/LLM.txt` | ESLint, TypeScript, utilities |
+
+### **🔄 Protocol Decision Tree**
+
+**New Token Launch**
+```
+Is this a new token? 
+├─ Yes → Start with DBC (studio/LLM.txt)
+│  ├─ Need fair launch? → DBC with bonding curve
+│  └─ Ready for AMM? → Migrate DBC → DAMM V2
+└─ No → Existing token pools
+   ├─ Standard AMM → DAMM V2 (studio/LLM.txt)  
+   ├─ Yield farming → DAMM V1 (studio/LLM.txt)
+   └─ Advanced LP → DLMM (studio/LLM.txt)
+```
+
+### **⚡ Quick Command Reference**
+
+| **Operation** | **Command** | **Details** |
+|---------------|-------------|-------------|
+| Studio actions | `pnpm studio [action-name]` | All protocol operations |
+| Frontend dev | `pnpm scaffold dev` | Run all scaffold dev servers |
+| Type checking | `pnpm type-check` | Validate TypeScript across repo |
+| Linting | `pnpm lint` | Check all workspaces |
+| Build all | `pnpm build` | Compile all packages |
+| Clean all | `pnpm clean` | Remove artifacts and node_modules |
+| Format code | `pnpm format` | Format all code with Prettier |
+| Check formatting | `pnpm format:check` | Check code formatting |
+| Validate environment | `pnpm validate-env` | Validate environment setup |
+| Sync dependencies | `pnpm syncpack:fix` | Fix dependency mismatches |
+
+## 📁 Hierarchical Repository Structure
+
+```
+meteora-invent/
+├── 📄 LLM.txt                        # THIS FILE - Repository navigation & setup
+├── 📄 package.json                   # Root scripts & workspace configuration
+├── 📄 turbo.json                     # Build system configuration
+├── 📄 pnpm-workspace.yaml            # Workspace definitions
+│
+├── 🏗️ studio/                        # Scripts - Program scripts (@meteora-invent/studio)
+│   ├── 📄 LLM.txt                    # ⭐ STUDIO MASTER GUIDE (updated & comprehensive)
+│   ├── 📄 package.json               # Studio-specific scripts (pnpm studio ...)
+│   ├── 📄 README.md                  # Studio documentation
+│   ├── 📁 config/                    # ⚙️ Configuration files (AI modifies these)
+│   │   ├── alpha_vault_config.jsonc  # Alpha Vault settings
+│   │   ├── dbc_config.jsonc          # Dynamic Bonding Curve settings
+│   │   ├── damm_v1_config.jsonc      # DAMM V1 pool settings
+│   │   ├── damm_v2_config.jsonc      # DAMM V2 pool settings
+│   │   └── dlmm_config.jsonc         # DLMM pool settings
+│   ├── 📁 data/                      # Static data files and examples
+│   │   ├── image/                    # Sample token images
+│   │   ├── kv_proof_example.json     # KV proof examples
+│   │   ├── kv_proofs/                # KV proof data
+│   │   └── whitelist_wallet_example.csv # Wallet whitelist examples
+│   ├── 📁 src/                       # 🔒 Source code (AI never modifies)
+│   │   ├── actions/                  # Executable protocol actions
+│   │   │   ├── alpha_vault/          # Alpha Vault actions
+│   │   │   ├── damm_v1/              # DAMM V1 actions
+│   │   │   ├── damm_v2/              # DAMM V2 actions
+│   │   │   ├── dbc/                  # DBC actions
+│   │   │   ├── dlmm/                 # DLMM actions
+│   │   │   ├── presale_vault/        # Presale Vault actions
+│   │   │   └── settings/             # Utility actions (generate keypair, airdrop SOL on devnet/localnet)
+│   │   ├── lib/                      # Protocol-specific libraries
+│   │   ├── helpers/                  # Utility functions
+│   │   ├── tests/                    # Test artifacts and data
+│   │   └── utils/                    # Types and constants
+│   ├── 📁 test-ledger/               # Local validator data (generated)
+│   ├── 📄 .env                       # Environment variables (create from .env.example)
+│   ├── 📄 keypair.json               # Generated wallet file
+│   ├── 📄 baseMintKeypair.json       # Generated base mint keypair
+│   └── 📄 mint-keypair.json          # Generated mint keypair
+│
+├── 🎨 scaffolds/                     # FRONTEND - Production-ready templates
+│   ├── 📄 LLM.txt                    # Scaffold overview & usage guide
+│   └── 📁 fun-launch/                # Token launchpad template (@meteora-invent/scaffold/fun-launch)
+│       ├── 📄 LLM.txt                # ⭐ DETAILED FRONTEND GUIDE
+│       ├── 📄 README.md              # Fun Launch specific documentation
+│       ├── 📄 package.json           # Next.js application scripts
+│       ├── 📄 next.config.ts         # Next.js configuration
+│       ├── 📄 tailwind.config.js     # Tailwind CSS configuration
+│       ├── 📄 tsconfig.json          # TypeScript configuration
+│       ├── 📁 src/                   # React components & pages
+│       │   ├── components/           # Reusable UI components
+│       │   │   ├── ui/               # Base components (Button, Dialog, etc.)
+│       │   │   ├── Token/            # Token-specific components
+│       │   │   ├── TokenChart/       # TradingView chart integration
+│       │   │   ├── TokenHeader/      # Token page headers
+│       │   │   ├── TokenTable/       # Transaction and holder tables
+│       │   │   ├── Terminal/         # Trading interface
+│       │   │   ├── Explore/          # Token exploration components
+│       │   │   └── CreatePoolButton.tsx # Pool creation
+│       │   ├── pages/                # Next.js routes
+│       │   │   ├── _app.tsx          # App wrapper
+│       │   │   ├── index.tsx         # Home/explore page
+│       │   │   ├── create-pool.tsx   # Pool creation page
+│       │   │   ├── token/[tokenId].tsx # Dynamic token pages
+│       │   │   └── api/              # API routes
+│       │   ├── contexts/             # React contexts for state
+│       │   ├── hooks/                # Custom React hooks
+│       │   ├── lib/                  # Utility functions
+│       │   ├── types/                # TypeScript definitions
+│       │   ├── icons/                # SVG icons & components
+│       │   └── styles/               # Global styles
+│       ├── 📁 public/                # Static assets
+│       │   ├── favicon.ico
+│       │   ├── coins/                # Token icons
+│       │   └── *.svg                 # Various UI icons
+│       └── 📄 .env.example           # Frontend environment template
+│
+└── 📦 packages/                      # SHARED - Reusable configurations
+    ├── 📄 LLM.txt                    # Shared packages guide
+    ├── 📁 config/                    # Shared configurations
+    │   ├── eslint/                   # ESLint configurations (@meteora-invent/config-eslint)
+    │   │   ├── index.js              # Base ESLint config
+    │   │   ├── next.js               # Next.js specific rules
+    │   │   ├── node.js               # Node.js specific rules
+    │   │   └── package.json
+    │   ├── prettier/                 # Prettier configurations (@meteora-invent/config-prettier)
+    │   │   ├── index.js              # Prettier formatting rules
+    │   │   └── package.json
+    │   ├── typescript/               # TypeScript configurations (@meteora-invent/config-typescript)
+    │   │   ├── base.json             # Common TypeScript settings
+    │   │   ├── nextjs.json           # Next.js projects
+    │   │   ├── node.json             # Node.js scripts
+    │   │   └── package.json
+    │   └── tsconfig.json             # Root TypeScript config
+    └── 📁 shared/                    # Shared utilities
+        └── utils/                    # Common utility functions (@meteora-invent/utils)
+            ├── src/                  # Source code
+            │   ├── formatting.ts     # Text formatting utilities
+            │   ├── numbers.ts        # Number formatting utilities
+            │   └── index.ts          # Main exports
+            ├── package.json
+            └── tsconfig.json
+```
+
+## 🛡️ AI Safety & Security Guidelines
+
+### **Critical Rules for AI**
+1. ✅ **Always Read LLM.txt First**: Each directory contains specific guidance
+2. ✅ **Use Dry-Run Mode**: Set `"dryRun": true` in configs for testing
+3. ✅ **Validate Before Execute**: Run validation commands before operations
+4. ✅ **Test on Devnet**: Never start with mainnet for new configurations
+5. ✅ **Follow File Permissions**: Only modify files in designated directories
+
+### **Files AI Can Modify**
+- `studio/config/*.jsonc` - Protocol configurations
+- `scaffolds/*/.*env*` - Environment configurations  
+- `scaffolds/*/src/**` - Frontend source code (when building UIs)
+
+### **Files AI Must NEVER Modify**
+- `studio/src/**` - Program logic and actions
+- `**/package.json` - Dependencies and scripts (unless explicitly requested)
+- `**/node_modules/**` - Generated dependencies
+- `**/.git/**` - Git repository data
+
+### **Environment Security**
+```bash
+# ✅ GOOD - Use environment variables
+PAYER_PRIVATE_KEY=your_private_key_in_base58_format
+RPC_URL=https://your-rpc-endpoint.com
+
+# ❌ BAD - Never hardcode in source
+const privateKey = "actual_private_key_here"  // NEVER DO THIS
+```
+
+## 🌍 Network Configuration Guide
+
+### **Network Selection by Use Case**
+
+| **Network** | **Purpose** | **Cost** | **Setup** |
+|-------------|-------------|----------|-----------|
+| **Localnet** | Development & Testing | Free | `pnpm studio start-test-validator` |
+| **Devnet** | Integration Testing | Free (faucet) | Set `rpcUrl: "https://api.devnet.solana.com"` |
+| **Mainnet** | Production | Real SOL | Set `rpcUrl: "https://api.mainnet-beta.solana.com"` |
+
+### **RPC Endpoint Recommendations**
+- **Development**: Public RPC (free, rate-limited)
+- **Production**: Private RPC (Helius, QuickNode, Alchemy)
+- **High Volume**: Dedicated RPC with higher rate limits
+
+## 🎯 Next Steps for AI
+
+### **New to Repository?**
+1. **To do actions on Meteora programs**: `studio/LLM.txt` - Comprehensive studio guide
+2. **To build the frontend user interface**: `scaffolds/fun-launch/LLM.txt` - UI development
+3. **Common configuration files**: `packages/LLM.txt` - Shared tools setup
+
+
+## 📚 Support & Resources
+
+### **Documentation**
+- **Meteora Docs**: https://docs.meteora.ag - Meteora protocol documentation
+- **Next.js Docs**: https://nextjs.org/docs - Next.js frontend framework documentation
+- **Solana Docs**: https://solana.com/docs - Solana blockchain fundamentals
+
+### **Tools & Explorers**
+- **Solana Explorer**: https://explorer.solana.com - Transaction verification
+- **Jupiter**: https://jup.ag - Token swaps and aggregation
+- **DexScreener**: https://dexscreener.com/solana - Pool analytics
+
+### **Development Tools**
+- **Solana CLI**: Command-line tools for Solana
+- **Anchor**: Framework for Solana program development
+- **TypeScript**: Type-safe development
+
+---
+
+**🎯 Remember**: This is a hierarchical system - each LLM.txt provides progressively more detailed guidance as you navigate deeper into specific workspaces. Always start with the LLM.txt in your target directory!

--- a/skills/meteora-launch/references/actions.md
+++ b/skills/meteora-launch/references/actions.md
@@ -1,0 +1,572 @@
+# Meteora Invent — Full Action Reference
+
+All 27 studio actions documented with parameters, outputs, and usage notes.
+
+## Contents
+
+- [Setup Actions](#setup-actions) — `generate-keypair`, `airdrop-sol`, `start-test-validator`
+- [DBC Actions](#dbc-dynamic-bonding-curve-actions) — `dbc-create-config/pool`, `dbc-swap`, `dbc-claim-trading-fee`, `dbc-migrate-to-damm-v1/v2`, `dbc-transfer-pool-creator`
+- [DLMM Actions](#dlmm-dynamic-liquidity-market-maker-actions) — `dlmm-create-pool`, `dlmm-seed-liquidity-lfg/single-bin`, `dlmm-set-pool-status`
+- [DAMM v2 Actions](#damm-v2-actions) — create balanced/one-sided, add/remove liquidity, claim fee, split/close position, refresh vesting
+- [DAMM v1 Actions](#damm-v1-actions) — create pool, lock liquidity, stake2earn farm
+- [Alpha Vault Actions](#alpha-vault-actions) — `alpha-vault-create`
+- [Presale Vault Actions](#presale-vault-actions) — `presale-vault-create`
+- [Quick Reference Table](#quick-reference-table)
+
+---
+
+## Setup Actions
+
+### `generate-keypair`
+Generate a new Solana keypair and optionally airdrop SOL on devnet.
+
+```bash
+pnpm studio generate-keypair
+pnpm studio generate-keypair --network devnet --airdrop
+```
+
+**Flags:**
+| Flag | Type | Description |
+|------|------|-------------|
+| `--network` | string | `mainnet-beta` \| `devnet` \| `localnet` |
+| `--airdrop` | boolean | Airdrop 5 SOL on devnet after generation |
+
+**Output:** `keypair.json` saved to working directory + public key logged.
+
+---
+
+### `airdrop-sol`
+Airdrop SOL to your wallet (devnet only).
+
+```bash
+pnpm studio airdrop-sol --network devnet --amount 5
+```
+
+**Flags:**
+| Flag | Type | Description |
+|------|------|-------------|
+| `--network` | string | Must be `devnet` or `localnet` |
+| `--amount` | number | SOL amount to airdrop (max 5 per request) |
+
+---
+
+### `start-test-validator`
+Start a local Solana test validator for localnet testing.
+
+```bash
+pnpm studio start-test-validator
+```
+
+**Output:** Local validator running at `http://localhost:8899`
+
+---
+
+## DBC (Dynamic Bonding Curve) Actions
+
+### `dbc-create-config`
+Create a reusable DBC configuration account for your launch partner.
+
+```bash
+pnpm studio dbc-create-config
+pnpm studio dbc-create-config --config studio/config/dbc_config.jsonc
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "quoteMint": "So11111111111111111111111111111111111111112", // Quote token (SOL default)
+  "feeClaimer": "YOUR_FEE_CLAIMER_PUBKEY",
+  "leftoverReceiver": "YOUR_RECEIVER_PUBKEY",
+  "migrationFeeOption": 0,      // 0-7: different fee tiers for DAMM migration
+  "migrationOption": 0,          // 0=DAMM v1, 1=DAMM v2
+  "tokenType": 0,                // 0=SPL, 1=Token 2022
+  "partnerLpPercentage": 50,     // Partner LP allocation on migration
+  "creatorLpPercentage": 50,     // Creator LP allocation on migration
+  "partnerLockedLpPercentage": 0,
+  "creatorLockedLpPercentage": 0,
+  "collectFeeMode": 0,           // 0=quote only, 1=both tokens
+  "migrationQuoteThreshold": "1000000000", // lamports triggering migration
+  "sqrtStartPrice": "...",       // Starting sqrt price (u128)
+  "curve": [...]                 // Price curve points
+}
+```
+
+**Output:** Config account pubkey logged. Save for use in pool creation.
+
+---
+
+### `dbc-create-pool`
+Launch a token with a Dynamic Bonding Curve. Creates the base mint + pool.
+
+```bash
+pnpm studio dbc-create-pool
+pnpm studio dbc-create-pool --baseMint <MINT_ADDRESS>   # Use existing mint
+pnpm studio dbc-create-pool --config studio/config/dbc_config.jsonc
+```
+
+**Flags:**
+| Flag | Type | Description |
+|------|------|-------------|
+| `--baseMint` | pubkey | Use existing SPL token mint |
+| `--config` | path | Path to config file |
+
+**What it does:**
+1. Creates base token mint (if no `--baseMint`)
+2. Creates DBC virtual pool account
+3. Seeds initial liquidity from config
+4. Sets fee scheduler (if configured)
+
+**Output:** Base mint address + pool address logged.
+
+**⚠️ Required SOL:** ~0.05 SOL for account rent + fees
+
+---
+
+### `dbc-swap`
+Buy or sell tokens on the bonding curve.
+
+```bash
+pnpm studio dbc-swap --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "inAmount": "1000000000",     // Amount in lamports/smallest unit
+  "minimumAmountOut": "0",      // Slippage protection
+  "swapBaseForQuote": false,    // false=buy base token, true=sell base token
+  "referralTokenAccount": null  // Optional referral
+}
+```
+
+---
+
+### `dbc-claim-trading-fee`
+Claim accumulated trading fees from a DBC pool.
+
+```bash
+pnpm studio dbc-claim-trading-fee --baseMint <MINT_ADDRESS>
+```
+
+**Requirements:**
+- Must be called by `feeClaimer` set in the config account
+- Fees accumulate automatically with every swap
+
+**Output:** Fee amounts claimed logged.
+
+---
+
+### `dbc-migrate-to-damm-v1`
+Migrate completed DBC pool to DAMM v1 AMM.
+
+```bash
+pnpm studio dbc-migrate-to-damm-v1 --baseMint <MINT_ADDRESS>
+```
+
+**Requirements:**
+- Pool `quoteReserve` must exceed `migrationQuoteThreshold`
+- Config `migrationOption` must be 0
+
+**What it does:**
+1. Closes DBC virtual pool
+2. Creates DAMM v1 pool with all liquidity
+3. Distributes LP tokens per partner/creator percentages
+4. Optionally locks LP tokens per config
+
+---
+
+### `dbc-migrate-to-damm-v2`
+Migrate completed DBC pool to DAMM v2 AMM.
+
+```bash
+pnpm studio dbc-migrate-to-damm-v2 --baseMint <MINT_ADDRESS>
+```
+
+**Requirements:**
+- Pool `quoteReserve` must exceed `migrationQuoteThreshold`
+- Config `migrationOption` must be 1
+
+**What it does:**
+1. Closes DBC virtual pool
+2. Creates DAMM v2 pool with all liquidity
+3. Creates position NFTs for LP holders
+4. Distributes positions per partner/creator percentages
+5. Optionally locks positions with vesting schedule
+
+---
+
+### `dbc-transfer-pool-creator`
+Transfer creator rights of a DBC pool to a new address.
+
+```bash
+pnpm studio dbc-transfer-pool-creator --baseMint <MINT_ADDRESS> --newCreator <PUBKEY>
+```
+
+---
+
+## DLMM (Dynamic Liquidity Market Maker) Actions
+
+### `dlmm-create-pool`
+Create a concentrated liquidity pool with bin-based architecture.
+
+```bash
+pnpm studio dlmm-create-pool --baseMint <MINT_ADDRESS>
+pnpm studio dlmm-create-pool --config studio/config/dlmm_config.jsonc
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "quoteMint": "So11111111111111111111111111111111111111112",
+  "binStep": 10,               // Price step per bin (in bps, e.g. 10 = 0.1%)
+  "baseFactor": 10000,         // Base fee factor
+  "feeBps": 100,               // Base fee in bps (100 = 1%)
+  "initialPrice": 0.001,       // Starting price in quote token
+  "priceRoundingUp": true,
+  "activationType": 0,         // 0=slot, 1=timestamp
+  "activationPoint": null,     // null=immediate
+  "hasAlphaVault": false       // Set true if adding Alpha Vault after
+}
+```
+
+**Output:** Pool address logged.
+
+---
+
+### `dlmm-seed-liquidity-lfg`
+Seed DLMM pool with liquidity using LFG (Let's F***ing Go) curved distribution.
+
+```bash
+pnpm studio dlmm-seed-liquidity-lfg --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "baseAmount": "1000000000000", // Total base tokens to seed
+  "quoteAmount": "10000000000",  // Total quote tokens to seed
+  "minPrice": 0.0005,            // Lower price bound
+  "maxPrice": 0.002,             // Upper price bound
+  "curvature": 0.3,              // Distribution shape (0=flat, 1=steep)
+  "seedLiquidityByOperator": false
+}
+```
+
+**When to use:** Better for launch scenarios where you want a natural price curve.
+
+---
+
+### `dlmm-seed-liquidity-single-bin`
+Seed DLMM pool with all liquidity concentrated in a single price bin.
+
+```bash
+pnpm studio dlmm-seed-liquidity-single-bin --baseMint <MINT_ADDRESS>
+```
+
+**When to use:** When you need exact price control, or for stable pairs.
+
+---
+
+### `dlmm-set-pool-status`
+Enable or disable trading on a DLMM pool.
+
+```bash
+pnpm studio dlmm-set-pool-status --poolAddress <POOL_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "poolStatus": 0   // 0=enabled, 1=disabled
+}
+```
+
+---
+
+## DAMM v2 Actions
+
+### `damm-v2-create-balanced-pool`
+Create a DAMM v2 pool with equal amounts of both tokens.
+
+```bash
+pnpm studio damm-v2-create-balanced-pool --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "quoteMint": "So11111111111111111111111111111111111111112",
+  "baseAmount": "1000000000000",
+  "quoteAmount": "10000000000",
+  "feeBps": 100,                  // 100 = 1%
+  "activationType": 0,            // 0=slot, 1=timestamp
+  "activationPoint": null,        // null=immediate
+  "hasAlphaVault": false,
+  "tokenDecimal": 9,              // Base token decimals
+  "customizableFees": {
+    "tradeFeeNumerator": 100,
+    "protocolTradeFeePct": 20
+  }
+}
+```
+
+---
+
+### `damm-v2-create-one-sided-pool`
+Create a DAMM v2 pool using only base tokens (no quote required upfront).
+
+```bash
+pnpm studio damm-v2-create-one-sided-pool --baseMint <MINT_ADDRESS>
+```
+
+**When to use:** Project provides only base tokens; LPs add quote tokens later.
+
+**Key Config Fields:**
+```jsonc
+{
+  "baseAmount": "1000000000000",  // Only base token needed
+  "initialPrice": 0.001,          // Starting price
+  "maxPrice": 0.01,               // Upper bound
+  "feeBps": 100
+}
+```
+
+---
+
+### `damm-v2-add-liquidity`
+Add liquidity to an existing DAMM v2 pool.
+
+```bash
+pnpm studio damm-v2-add-liquidity --poolAddress <POOL_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "tokenAAmount": "1000000000",
+  "tokenBAmount": "10000000",
+  "slippage": 0.5              // Slippage tolerance in %
+}
+```
+
+---
+
+### `damm-v2-remove-liquidity`
+Remove liquidity from a DAMM v2 pool position.
+
+```bash
+pnpm studio damm-v2-remove-liquidity --poolAddress <POOL_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "lpAmount": "1000000000",    // LP tokens to burn
+  "tokenAMin": "0",            // Min tokenA out (slippage)
+  "tokenBMin": "0"             // Min tokenB out (slippage)
+}
+```
+
+---
+
+### `damm-v2-claim-position-fee`
+Claim accumulated trading fees from a DAMM v2 position.
+
+```bash
+pnpm studio damm-v2-claim-position-fee --poolAddress <POOL_ADDRESS>
+```
+
+**Output:** Fee amounts (tokenA + tokenB) logged.
+
+---
+
+### `damm-v2-split-position`
+Split an existing DAMM v2 position into two separate positions.
+
+```bash
+pnpm studio damm-v2-split-position --poolAddress <POOL_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "splitLpAmount": "500000000"  // Amount of LP to split into new position
+}
+```
+
+---
+
+### `damm-v2-close-position`
+Close a DAMM v2 position and withdraw all liquidity.
+
+```bash
+pnpm studio damm-v2-close-position --poolAddress <POOL_ADDRESS>
+```
+
+---
+
+### `damm-v2-refresh-vesting`
+Refresh the vesting schedule for a locked DAMM v2 position.
+
+```bash
+pnpm studio damm-v2-refresh-vesting --poolAddress <POOL_ADDRESS>
+```
+
+---
+
+## DAMM v1 Actions
+
+### `damm-v1-create-pool`
+Create a DAMM v1 constant-product AMM pool.
+
+```bash
+pnpm studio damm-v1-create-pool --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "quoteMint": "So11111111111111111111111111111111111111112",
+  "baseAmount": "1000000000000",
+  "quoteAmount": "10000000000",
+  "feeBps": 100,
+  "activationType": 0,
+  "activationPoint": null,
+  "hasAlphaVault": false
+}
+```
+
+---
+
+### `damm-v1-lock-liquidity`
+Lock LP tokens from a DAMM v1 pool to prevent withdrawal.
+
+```bash
+pnpm studio damm-v1-lock-liquidity --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "lockDuration": 7776000   // Lock duration in seconds (e.g., 90 days)
+}
+```
+
+---
+
+### `damm-v1-create-stake2earn-farm`
+Create a Stake2Earn farm on a DAMM v1 pool for LP incentives.
+
+```bash
+pnpm studio damm-v1-create-stake2earn-farm --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "rewardMint": "REWARD_TOKEN_MINT",
+  "rewardAmount": "1000000000000",  // Total rewards
+  "rewardDuration": 7776000         // Duration in seconds
+}
+```
+
+---
+
+### `damm-v1-lock-liquidity-stake2earn`
+Lock LP tokens and connect them to a Stake2Earn farm.
+
+```bash
+pnpm studio damm-v1-lock-liquidity-stake2earn --baseMint <MINT_ADDRESS>
+```
+
+---
+
+## Alpha Vault Actions
+
+### `alpha-vault-create`
+Create an Alpha Vault on top of an existing DAMM or DLMM pool.
+
+```bash
+pnpm studio alpha-vault-create --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "poolType": "dlmm",            // "dlmm" | "damm"
+  "vaultMode": "fcfs",           // "fcfs" | "prorata"
+  "depositingPoint": null,       // Start time (null=immediate)
+  "startVestingPoint": null,     // Vesting start
+  "endVestingPoint": null,       // Vesting end
+  "maxBuyingCap": "0",           // 0=no cap
+  "individualDepositingCap": "0",
+  "escrowFee": "0",
+  "whitelistMode": 0,            // 0=no whitelist, 1=whitelist required
+  "alphaVaultType": 0            // 0=default
+}
+```
+
+**Modes:**
+- `fcfs` — First Come First Served (fastest depositors get allocation)
+- `prorata` — All depositors get proportional allocation
+
+---
+
+## Presale Vault Actions
+
+### `presale-vault-create`
+Create a generic presale vault for token distribution.
+
+```bash
+pnpm studio presale-vault-create --baseMint <MINT_ADDRESS>
+```
+
+**Key Config Fields:**
+```jsonc
+{
+  "quoteMint": "EPjFWdd5Au...",   // Payment token (USDC etc.)
+  "presaleAmount": "1000000000000",
+  "presaleRate": 1000,             // How many base tokens per quote token
+  "depositingPoint": 0,            // Start slot/timestamp
+  "endDepositingPoint": 1000000,   // End slot/timestamp
+  "startVestingPoint": 1000001,
+  "endVestingPoint": 2000000,
+  "maxBuyingCap": "0",
+  "escrowFee": "0",
+  "whitelistMode": 0,
+  "vaultMode": "prorata"           // "fcfs" | "prorata"
+}
+```
+
+---
+
+## Quick Reference Table
+
+| Action | Command | Min SOL | Network |
+|--------|---------|---------|---------|
+| Generate keypair | `generate-keypair` | 0 | Any |
+| Airdrop SOL | `airdrop-sol` | 0 | Devnet only |
+| DBC: Create config | `dbc-create-config` | 0.01 | Any |
+| DBC: Create pool | `dbc-create-pool` | 0.05 | Any |
+| DBC: Swap | `dbc-swap` | 0.001 | Any |
+| DBC: Claim fee | `dbc-claim-trading-fee` | 0.001 | Any |
+| DBC: Migrate v1 | `dbc-migrate-to-damm-v1` | 0.05 | Any |
+| DBC: Migrate v2 | `dbc-migrate-to-damm-v2` | 0.05 | Any |
+| DLMM: Create pool | `dlmm-create-pool` | 0.05 | Any |
+| DLMM: Seed LFG | `dlmm-seed-liquidity-lfg` | 0.01 | Any |
+| DLMM: Seed single bin | `dlmm-seed-liquidity-single-bin` | 0.01 | Any |
+| DLMM: Set status | `dlmm-set-pool-status` | 0.001 | Any |
+| DAMM v2: Balanced pool | `damm-v2-create-balanced-pool` | 0.05 | Any |
+| DAMM v2: One-sided pool | `damm-v2-create-one-sided-pool` | 0.05 | Any |
+| DAMM v2: Add liquidity | `damm-v2-add-liquidity` | 0.01 | Any |
+| DAMM v2: Remove liquidity | `damm-v2-remove-liquidity` | 0.001 | Any |
+| DAMM v2: Claim fee | `damm-v2-claim-position-fee` | 0.001 | Any |
+| DAMM v2: Split position | `damm-v2-split-position` | 0.01 | Any |
+| DAMM v2: Close position | `damm-v2-close-position` | 0.001 | Any |
+| DAMM v2: Refresh vesting | `damm-v2-refresh-vesting` | 0.001 | Any |
+| DAMM v1: Create pool | `damm-v1-create-pool` | 0.05 | Any |
+| DAMM v1: Lock liquidity | `damm-v1-lock-liquidity` | 0.01 | Any |
+| DAMM v1: Create farm | `damm-v1-create-stake2earn-farm` | 0.05 | Any |
+| DAMM v1: Lock + farm | `damm-v1-lock-liquidity-stake2earn` | 0.01 | Any |
+| Alpha Vault: Create | `alpha-vault-create` | 0.05 | Any |
+| Presale Vault: Create | `presale-vault-create` | 0.05 | Any |

--- a/skills/meteora-launch/references/example_dbc_config.jsonc
+++ b/skills/meteora-launch/references/example_dbc_config.jsonc
@@ -1,0 +1,235 @@
+{
+  /* rpcUrl is required. You can switch between mainnet, devnet and localnet or use your own RPC URL. */
+  "rpcUrl": "https://api.devnet.solana.com", // mainnet: https://api.mainnet-beta.solana.com | devnet: https://api.devnet.solana.com | localnet: http://localhost:8899
+
+  /* dryRun is required. If true, transactions will be simulated and not executed. If false, transactions will be executed. */
+  "dryRun": false,
+
+  /* keypairFilePath is required and will be the payer + signer for all transactions */
+  "keypairFilePath": "./keypair.json",
+
+  /* computeUnitPriceMicroLamports is required and can be adjusted to fit your needs */
+  "computeUnitPriceMicroLamports": 100000,
+
+  /* quoteMint is required for the following actions:
+   * 1. dbc-create-config
+   * 2. dbc-create-pool (if there is no configKeyAddress)
+   * SOL: So11111111111111111111111111111111111111112 | USDC: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v | any other token address
+   */
+  "quoteMint": "So11111111111111111111111111111111111111112",
+
+  /* dbcConfig is only used in the following actions:
+   * 1. dbc-create-config
+   * 2. dbc-create-pool (if there is no --config flag indicated in the command)
+   */
+  "dbcConfig": {
+    "buildCurveMode": 0, // 0 - buildCurve | 1 - buildCurveWithMarketCap | 2 - buildCurveWithTwoSegments | 3 - buildCurveWithLiquidityWeights | 4 - buildCurveWithMidPrice | 5 - buildCurveWithCustomSqrtPrices
+
+    /* Only use the following parameters for buildCurveMode: 0 (buildCurve)
+     * 1. percentageSupplyOnMigration
+     * 2. migrationQuoteThreshold
+     */
+    "percentageSupplyOnMigration": 20, // percentage of total token supply to be migrated
+    "migrationQuoteThreshold": 10, // migration quote threshold needed to migrate the DBC token pool
+
+    /* Only use the following parameters for buildCurveMode: 1 (buildCurveWithMarketCap)
+     * 1. initialMarketCap
+     * 2. migrationMarketCap
+     */
+    // "initialMarketCap": 20, // the market cap of the DBC token pool when the pool is created specified in terms of quoteMint (not in lamports)
+    // "migrationMarketCap": 600, // the market cap of the DBC token pool when the pool graduates specified in terms of quoteMint (not in lamports)
+
+    /* Only use the following parameters for buildCurveMode: 2 (buildCurveWithTwoSegments)
+     * 1. initialMarketCap
+     * 2. migrationMarketCap
+     * 3. percentageSupplyOnMigration
+     */
+    // "initialMarketCap": 20, // the market cap of the DBC token pool when the pool is created specified in terms of quoteMint (not in lamports)
+    // "migrationMarketCap": 600, // the market cap of the DBC token pool when the pool graduates specified in terms of quoteMint (not in lamports)
+    // "percentageSupplyOnMigration": 20, // percentage of total token supply to be migrated
+
+    /* Only use the following parameters for buildCurveMode: 3 (buildCurveWithLiquidityWeights)
+     * 1. initialMarketCap
+     * 2. migrationMarketCap
+     * 3. liquidityWeights
+     */
+    // "initialMarketCap": 20, // the market cap of the DBC token pool when the pool is created specified in terms of quoteMint (not in lamports)
+    // "migrationMarketCap": 600, // the market cap of the DBC token pool when the pool graduates specified in terms of quoteMint (not in lamports)
+    // "liquidityWeights": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], // a array of 16 liquidity weights for each liquidity segment in the curve
+
+    /* Only use the following parameters for buildCurveMode: 4 (buildCurveWithMidPrice)
+     * 1. initialMarketCap
+     * 2. migrationMarketCap
+     * 3. midPrice
+     * 4. percentageSupplyOnMigration
+     */
+    // "initialMarketCap": 20, // the market cap of the DBC token pool when the pool is created specified in terms of quoteMint (not in lamports)
+    // "migrationMarketCap": 600, // the market cap of the DBC token pool when the pool graduates specified in terms of quoteMint (not in lamports)
+    // "midPrice": 0.001, // the mid-point price of the curve in terms of quoteMint
+    // "percentageSupplyOnMigration": 20, // percentage of total token supply to be migrated
+
+    /* Only use the following parameters for buildCurveMode: 5 (buildCurveWithCustomSqrtPrices)
+     * 1. prices - array of decimal prices in ascending order (at least 2 elements).
+     * 2. liquidityWeights - optional weights for each segment (length must be prices.length - 1)
+     */
+    // "prices": [0.00001, 0.0005, 0.001, 0.01], // array of decimal prices (ascending order). First = starting price, Last = migration price
+    // "liquidityWeights": [1, 2, 3], // optional: weights for each segment. If omitted, liquidity is distributed evenly
+
+    /* Token Configuration */
+    "token": {
+      "totalTokenSupply": 1000000000, // total token supply (not in lamports)
+      "tokenBaseDecimal": 6, // token base decimal
+      "tokenQuoteDecimal": 9, // token quote decimal
+      "tokenType": 0, // 0 - SPL | 1 - Token 2022
+      "tokenUpdateAuthority": 1, // 0 - CreatorUpdateAuthority | 1 - Immutable | 2 - PartnerUpdateAuthority | 3 - CreatorUpdateAndMintAuthority | 4 - PartnerUpdateAndMintAuthority
+      "leftover": 0 // leftover tokens in the bonding curve (claimable once pool migrates)
+    },
+
+    /* Fee Configuration */
+    "fee": {
+      "baseFeeParams": {
+        "baseFeeMode": 0, // 0 - Fee Scheduler: Linear | 1 - Fee Scheduler: Exponential | 2 - Rate Limiter
+        "feeSchedulerParam": {
+          "startingFeeBps": 100, // starting fee (max 99% fee === 9900 bps)
+          "endingFeeBps": 100, // ending fee (minimum 0.01% fee === 1 bps)
+          "numberOfPeriod": 0, // number of period
+          "totalDuration": 0 // total duration (If activationType is 0 (slots), totalDuration = duration / 0.4 | If activationType is 1 (timestamp), totalDuration = duration)
+        }
+        /*
+              "baseFeeMode": 2, // 2 - Rate Limiter
+              "rateLimiterParam": {
+                  "baseFeeBps": 200, // base fee (max 99% base fee === 9900 bps)
+                  "feeIncrementBps": 200, // fee increment (max fee increment = 9900 bps - baseFeeBps)
+                  "referenceAmount": 1, // reference amount (not in lamports)
+                  "maxLimiterDuration": 3600 // if activationType is 0 (slots), maxLimiterDuration = duration / 0.4, if activationType is 1 (timestamp), maxLimiterDuration = duration)
+              }
+              */
+      },
+      "dynamicFeeEnabled": true, // If true, dynamic fee will add 20% of minimum base fee to the total fee.
+      "collectFeeMode": 0, // 0 - Quote Token | 1 - Output Token
+      "creatorTradingFeePercentage": 50, // Bonding curve trading fee sharing (0% to 100%) - 0% means all trading fees go to the partner
+      /* Pool Creation Fee
+       * Fee charged to token creators when they create a pool using this config.
+       * Partner claims 90% via claimPartnerPoolCreationFee(), Meteora claims 10%.
+       * Set to 0 for no fee, or between 0.001 SOL and 100 SOL.
+       */
+      "poolCreationFee": 0, // Pool creation fee in SOL (e.g., 0.1 for 0.1 SOL)
+      "enableFirstSwapWithMinFee": false // If true, the first swap on the pool will use the minimum fee instead of the starting fee (useful for creator bundled buys)
+    },
+
+    /* Migration Configuration */
+    "migration": {
+      "migrationOption": 1, // 0 - Migrate to DAMM v1 | 1 - Migrate to DAMM v2
+      "migrationFeeOption": 3, // 0 - LP Fee 0.25% | 1 - LP Fee 0.3% | 2 - LP Fee 1% | 3 - LP Fee 2% | 4 - LP Fee 4% | 5 - LP Fee 6% | 6 - Customizable
+      "migrationFee": {
+        "feePercentage": 0, // Percentage of fee taken from migration quote threshold once pool migrates (0% to 50%)
+        "creatorFeePercentage": 0 // Percentage of the migrationFee.feePercentage claimable by creator (0% to 100%)
+      }
+      /* Migrated Pool Fee (DAMM v2 only)
+       * Configure migratedPoolFee when using migrationFeeOption: 6 (Customizable) or when configuring marketCapFeeSchedulerParams.
+       * Note: When marketCapFeeSchedulerParams is configured, the SDK will automatically set migrationFeeOption to Customizable (6).
+       */
+      // "migratedPoolFee": {
+      //   "collectFeeMode": 0, // 0 - Quote Token | 1 - Output Token
+      //   "dynamicFee": 0, // 0: Disabled, 1: Enabled
+      //   "poolFeeBps": 100, // The pool fee in basis points. Minimum 10, Maximum 1000 bps. Required when marketCapFeeSchedulerParams is configured.
+      //   "baseFeeMode": 3, // 3 - FeeMarketCapSchedulerLinear | 4 - FeeMarketCapSchedulerExponential (only for DAMM v2)
+      //   "marketCapFeeSchedulerParams": {
+      //     "endingBaseFeeBps": 50, // The ending (minimum) base fee in basis points
+      //     "numberOfPeriod": 100, // The total number of fee reduction periods
+      //     "sqrtPriceStepBps": 100, // The sqrt price increase (in bps) required to advance one period
+      //     "schedulerExpirationDuration": 86400 // The maximum duration (seconds) after which the scheduler expires and defaults to minimum fee
+      //   }
+      // }
+    },
+
+    /* LP Distribution Configuration (must total 100%)
+     * IMPORTANT: At least 10% of LP must remain locked/vesting for at least 1 day post-migration.
+     *
+     * For DAMM v1: partnerPermanentLockedLiquidityPercentage + creatorPermanentLockedLiquidityPercentage >= 10%
+     *
+     * For DAMM v2: 3 options to achieve 10% locked/vesting:
+     *   Option 1 (Permanent Only): Set creator + partner permanent locked percentages >= 10% (LP locked forever)
+     *   Option 2 (Vesting Only): Use creator + partner vestingInfoParams with cliffDurationFromMigrationTime >= 86400 (1 day)
+     *   Option 3 (Combination): Mix permanent + vesting to reach 10% (5% permanent + 5% vesting >= 1 day)
+     */
+    "liquidityDistribution": {
+      "partnerLiquidityPercentage": 50, // Partner claimable LP (withdrawable LP once pool migrates)
+      "creatorLiquidityPercentage": 40, // Creator claimable LP (withdrawable LP once pool migrates)
+      "partnerPermanentLockedLiquidityPercentage": 5, // Partner locked LP (permanently locked LP once pool migrates) - counts toward 10% requirement
+      "creatorPermanentLockedLiquidityPercentage": 5 // Creator locked LP (permanently locked LP once pool migrates) - counts toward 10% requirement
+      /* LP Vesting (DAMM v2 only)
+       * Optional vesting schedule for partner/creator LP tokens after migration.
+       * Only applicable when migrationOption = 1 (DAMM v2).
+       * Note: At least 10% of LP must remain locked/vesting for at least 1 day post-migration.
+       */
+      // "partnerLiquidityVestingInfoParams": {
+      //   "vestingPercentage": 50,                // % of non-permanent LP to vest (0-100)
+      //   "bpsPerPeriod": 100,                    // BPS released per period (100 = 1%)
+      //   "numberOfPeriods": 100,                 // Total vesting periods
+      //   "cliffDurationFromMigrationTime": 86400, // Cliff delay in seconds (86400 = 1 day)
+      //   "totalDuration": 2592000                // Total vesting duration in seconds (30 days)
+      // },
+      // "creatorLiquidityVestingInfoParams": {
+      //   "vestingPercentage": 50,
+      //   "bpsPerPeriod": 100,
+      //   "numberOfPeriods": 100,
+      //   "cliffDurationFromMigrationTime": 86400,
+      //   "totalDuration": 2592000
+      // }
+    },
+
+    /* Locked Vesting Configuration */
+    "lockedVesting": {
+      "totalLockedVestingAmount": 0, // total locked vesting amount (not in lamports)
+      "numberOfVestingPeriod": 0, // number of vesting period
+      "cliffUnlockAmount": 0, // cliff unlock amount (not in lamports)
+      "totalVestingDuration": 0, // total vesting duration (in seconds)
+      "cliffDurationFromMigrationTime": 0 // cliff duration from migration time (in seconds)
+    },
+
+    "activationType": 1, // 0 - Slot | 1 - Timestamp
+
+    "leftoverReceiver": "YOUR_LEFTOVER_RECEIVER_ADDRESS", // leftover receiver address
+    "feeClaimer": "YOUR_FEE_CLAIMER_ADDRESS" // fee claimer address
+  },
+
+  /* dbcPool is only used in the following actions:
+   * 1. dbc-create-pool
+   */
+  "dbcPool": {
+    // "baseMintKeypairFilepath": "./mint-keypair.json", // optional base mint keypair file path
+    "creator": "YOUR_CREATOR_ADDRESS", // creator address
+    "name": "TOKEN_NAME", // token name
+    "symbol": "TOKEN_SYMBOL", // token symbol
+    "metadata": {
+      // "uri": "https://gateway.irys.xyz/123456789", // if you already have a metadata URI created, you can specify it here
+
+      /* Only use the following parameters for createBaseToken if you don't have an existing metadata uri
+       * This will create an image uri and a new metadata uri and upload everything to Irys
+       */
+      "image": "./data/image/test-token.jpg", // this can be a URL of the image address (e.g. https://example.com/token-image.png) or the image file path (e.g. ./data/image/test-token.jpg)
+      "description": "TOKEN_DESCRIPTION", // token description
+      "website": "https://example.com", // project website
+      "twitter": "https://x.com/yourproject", // twitter URL
+      "telegram": "https://t.me/yourproject" // telegram URL
+    }
+  },
+
+  /* dbcSwap is only used in the following actions:
+   * 1. dbc-swap (Buy or Sell)
+   */
+  "dbcSwap": {
+    "amountIn": 1.03, // the amount of quoteMint or baseMint to be swapped
+    "slippageBps": 100, // slippage in bps
+    "swapBaseForQuote": false, // if true, swap base for quote | if false, swap quote for base
+    "referralTokenAccount": null // optional referral token account address
+  },
+
+  /* dbcTransferPoolCreator is only used in the following actions:
+   * 1. dbc-transfer-pool-creator
+   */
+  "dbcTransferPoolCreator": {
+    "newCreator": "YOUR_NEW_CREATOR_ADDRESS" // new creator address
+  }
+}

--- a/skills/meteora-launch/references/setup.md
+++ b/skills/meteora-launch/references/setup.md
@@ -1,0 +1,62 @@
+# Meteora Invent — Setup Guide
+
+## Install the Toolkit
+
+```bash
+# Clone the official repo
+git clone https://github.com/MeteoraAg/meteora-invent
+cd meteora-invent
+
+# Install dependencies
+pnpm install
+```
+
+**Requirements:** Node.js >= 18, pnpm >= 10
+
+## Configure Environment
+
+```bash
+cp studio/.env.example studio/.env
+```
+
+Edit `studio/.env`:
+
+```env
+PAYER_PRIVATE_KEY=<your_wallet_private_key_in_base58>
+RPC_URL=<your_rpc_endpoint>
+```
+
+**RPC options:**
+- Public mainnet: `https://api.mainnet-beta.solana.com`
+- Public devnet: `https://api.devnet.solana.com`
+- Premium (recommended): [Helius](https://www.helius.dev/), QuickNode, Triton
+
+## Get a Wallet
+
+```bash
+# Generate a fresh keypair
+pnpm studio generate-keypair
+
+# On devnet — generate + airdrop 5 SOL
+pnpm studio generate-keypair --network devnet --airdrop
+```
+
+Or import an existing wallet: paste the base58 private key into `PAYER_PRIVATE_KEY`.
+
+## Local Testing (Optional)
+
+```bash
+# Start a local validator
+pnpm studio start-test-validator
+
+# Airdrop on localnet
+pnpm studio airdrop-sol --network localnet --amount 10
+```
+
+## Verify Setup
+
+```bash
+# Dry-run a DBC config create (no cost, just validates)
+# Set "dryRun": true in your config file first
+pnpm studio dbc-create-config
+```


### PR DESCRIPTION
Adds an OpenClaw AgentSkill that teaches AI agents how to use the meteora-invent CLI toolkit for Solana token launches and liquidity ops.

Skill covers all 27 studio actions across:
- DBC (Dynamic Bonding Curve) — token launches with auto-migration
- DAMM v2 — advanced AMM with dynamic fees and position NFTs
- DAMM v1 — constant product AMM with lending integration
- DLMM — concentrated liquidity with bin-based price ranges
- Alpha Vault — anti-bot mechanism and automated yield strategies
- Presale Vault — permissionless token presales

Usage (once installed in OpenClaw):
  clawhub install meteora-launch

Or via npm:
  npm install -g meteora-launch-skill