### PR TITLE
feat(damm-v2): add compounding fee pool creation support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,8 +283,8 @@ importers:
         specifier: ^1.1.14
         version: 1.1.14(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@meteora-ag/cp-amm-sdk':
-        specifier: ^1.3.3
-        version: 1.3.3(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
+        specifier: ^1.3.7
+        version: 1.3.7(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@meteora-ag/dlmm':
         specifier: ^1.9.3
         version: 1.9.3(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
@@ -1552,8 +1552,8 @@ packages:
   '@meteora-ag/cp-amm-sdk@1.1.0':
     resolution: {integrity: sha512-CFYSGLgSSTL5oDSrL5bx+oCi51rkvfuFXdMVDEZmnljlnyt2vxbrzRCkCTzxN7ABCYjuCvkLoVrT1JiBh39k2A==}
 
-  '@meteora-ag/cp-amm-sdk@1.3.3':
-    resolution: {integrity: sha512-C3ZX0fybGqqxvhq2sxJZIIsgyKVP+QpGFbl4OHyEBP/C88AU0/+1Nhof/64McRQxvPCgINE956e8ts4Z0UhPug==}
+  '@meteora-ag/cp-amm-sdk@1.3.7':
+    resolution: {integrity: sha512-k7vijBXhKtT4+geHcrRbLlgggXDgl3WtgsCTHAZAtzl1JEYeN0LopcbuOmeuRLEQVq73TlzSwhIlDCH6M3JyuA==}
 
   '@meteora-ag/dlmm@1.5.0':
     resolution: {integrity: sha512-d8DwhSrSSuIPfw6+9LLu2aXylKc7tS6FTnQzZcQYlGhrKIlABn97muasizBAcgMp80AR/bKEa6qtFCoQt4pqwA==}
@@ -11370,7 +11370,7 @@ snapshots:
     dependencies:
       '@cora-xyz/anchor-0.28.0': '@coral-xyz/anchor@0.28.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)'
       '@coral-xyz/anchor': 0.31.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
-      '@meteora-ag/cp-amm-sdk': 1.3.3(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@meteora-ag/cp-amm-sdk': 1.3.7(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@meteora-ag/dlmm': 1.5.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@meteora-ag/dynamic-amm-sdk': 1.4.1(@solana/buffer-layout@4.0.1)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@solana/buffer-layout': 4.0.1
@@ -11422,7 +11422,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@meteora-ag/cp-amm-sdk@1.3.3(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)':
+  '@meteora-ag/cp-amm-sdk@1.3.7(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.31.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)

--- a/studio/config/damm_v2_config.jsonc
+++ b/studio/config/damm_v2_config.jsonc
@@ -89,7 +89,7 @@
         // }
       },
       "dynamicFeeEnabled": true, // if dynamicFeeEnabled is true and dynamicFeeConfig is null, the default dynamic fee configuration will be 20% of the base fee
-      // "compoundingFeeBps": 5000 // Only used when collectFeeMode is 2 (Compounding). Percentage of trading fees compounded back into pool liquidity (bps, e.g. 5000 = 50%). Required for compounding mode.
+      // "compoundingFeeBps": 5000 // Only used when collectFeeMode is 2 (Compounding). Percentage of trading fees compounded back into pool liquidity (0 to 10000 bps, e.g. 5000 = 50%). Required for compounding mode.
       /* Optional Configuration.
        * Only used if you want to configure dynamic fee and not use the default dynamic fee configuration
        * Formula: dynamicFee = (variableFeeControl * (volatilityAccumulator * binStep)^2 + 99_999_999_999) / 100_000_000_000

--- a/studio/config/damm_v2_config.jsonc
+++ b/studio/config/damm_v2_config.jsonc
@@ -88,7 +88,7 @@
         //   "schedulerExpirationDuration": 86400 // maximum duration (seconds) after which scheduler expires and defaults to ending fee
         // }
       },
-      "dynamicFeeEnabled": true, // if dynamicFeeEnabled is true and dynamicFeeConfig is null, the default dynamic fee configuration will be 20% of the base fee
+      "dynamicFeeEnabled": true // if dynamicFeeEnabled is true and dynamicFeeConfig is null, the default dynamic fee configuration will be 20% of the base fee
       // "compoundingFeeBps": 5000 // Only used when collectFeeMode is 2 (Compounding). Percentage of trading fees compounded back into pool liquidity (0 to 10000 bps, e.g. 5000 = 50%). Required for compounding mode.
       /* Optional Configuration.
        * Only used if you want to configure dynamic fee and not use the default dynamic fee configuration

--- a/studio/config/damm_v2_config.jsonc
+++ b/studio/config/damm_v2_config.jsonc
@@ -88,7 +88,8 @@
         //   "schedulerExpirationDuration": 86400 // maximum duration (seconds) after which scheduler expires and defaults to ending fee
         // }
       },
-      "dynamicFeeEnabled": true // if dynamicFeeEnabled is true and dynamicFeeConfig is null, the default dynamic fee configuration will be 20% of the base fee
+      "dynamicFeeEnabled": true, // if dynamicFeeEnabled is true and dynamicFeeConfig is null, the default dynamic fee configuration will be 20% of the base fee
+      // "compoundingFeeBps": 5000 // Only used when collectFeeMode is 2 (Compounding). Percentage of trading fees compounded back into pool liquidity (bps, e.g. 5000 = 50%). Required for compounding mode.
       /* Optional Configuration.
        * Only used if you want to configure dynamic fee and not use the default dynamic fee configuration
        * Formula: dynamicFee = (variableFeeControl * (volatilityAccumulator * binStep)^2 + 99_999_999_999) / 100_000_000_000
@@ -101,7 +102,7 @@
       //   "maxVolatilityAccumulator": 239 // Maximum allowed volatility accumulator value (caps dynamic fee calculation)
       // }
     },
-    "collectFeeMode": 1, // 0 - Both Token | 1 - Token B Only
+    "collectFeeMode": 1, // 0 - Both Token | 1 - Token B Only | 2 - Compounding (balanced pool only — fees auto-compound back into liquidity)
     "activationType": 1, // 0 - Slot | 1 - Timestamp
     "activationPoint": null, // Activation time of the pool depending on activationType (Calculate in slots if activationType is 0 (slots) | Calculate in seconds if activationType is 1 (timestamp))
     "hasAlphaVault": false // If true, the alpha vault will be created after the pool is created

--- a/studio/package.json
+++ b/studio/package.json
@@ -53,7 +53,7 @@
     "@metaplex-foundation/umi-bundle-defaults": "^1.4.1",
     "@metaplex-foundation/umi-uploader-irys": "^1.4.1",
     "@meteora-ag/alpha-vault": "^1.1.14",
-    "@meteora-ag/cp-amm-sdk": "^1.3.3",
+    "@meteora-ag/cp-amm-sdk": "^1.3.7",
     "@meteora-ag/dlmm": "^1.9.3",
     "@meteora-ag/dynamic-amm-sdk": "^1.4.1",
     "@meteora-ag/dynamic-bonding-curve-sdk": "^1.5.3",

--- a/studio/src/helpers/config.ts
+++ b/studio/src/helpers/config.ts
@@ -274,10 +274,13 @@ export const CONFIG_SCHEMA = {
               },
             },
           },
+          compoundingFeeBps: {
+            type: 'number',
+          },
         },
         collectFeeMode: {
           type: 'number',
-          enum: [0, 1],
+          enum: [0, 1, 2],
         },
         activationType: {
           type: 'number',

--- a/studio/src/lib/damm_v2/index.ts
+++ b/studio/src/lib/damm_v2/index.ts
@@ -132,7 +132,12 @@ export async function createDammV2OneSidedPool(
   const initSqrtPrice = getSqrtPriceFromPrice(initPrice.toString(), baseDecimals, quoteDecimals);
   let minSqrtPrice = initSqrtPrice;
 
-  const liquidityDelta = getLiquidityDeltaFromAmountA(tokenAAmount, initSqrtPrice, maxSqrtPrice, collectFeeMode);
+  const liquidityDelta = getLiquidityDeltaFromAmountA(
+    tokenAAmount,
+    initSqrtPrice,
+    maxSqrtPrice,
+    collectFeeMode
+  );
 
   if (quoteAmount) {
     tokenBAmount = getAmountInLamports(quoteAmount, quoteDecimals);

--- a/studio/src/lib/damm_v2/index.ts
+++ b/studio/src/lib/damm_v2/index.ts
@@ -55,6 +55,13 @@ export async function createDammV2OneSidedPool(
       'Missing DAMM V2 configuration. Ensure "dammV2Config" is set in config/damm_v2_config.jsonc.'
     );
   }
+  if (config.dammV2Config.collectFeeMode === 2) {
+    throw new Error(
+      'Compounding fee mode (collectFeeMode: 2) does not support single-sided pools. ' +
+        'Use damm-v2-create-balanced-pool instead.'
+    );
+  }
+
   console.log('\n> Initializing one-sided DAMM V2 pool...');
 
   if (!config.quoteMint) {
@@ -125,7 +132,7 @@ export async function createDammV2OneSidedPool(
   const initSqrtPrice = getSqrtPriceFromPrice(initPrice.toString(), baseDecimals, quoteDecimals);
   let minSqrtPrice = initSqrtPrice;
 
-  const liquidityDelta = getLiquidityDeltaFromAmountA(tokenAAmount, initSqrtPrice, maxSqrtPrice);
+  const liquidityDelta = getLiquidityDeltaFromAmountA(tokenAAmount, initSqrtPrice, maxSqrtPrice, collectFeeMode);
 
   if (quoteAmount) {
     tokenBAmount = getAmountInLamports(quoteAmount, quoteDecimals);
@@ -175,7 +182,8 @@ export async function createDammV2OneSidedPool(
 
   const poolFeesParams: PoolFeesParams = {
     baseFee: baseFeeParams,
-    padding: [],
+    compoundingFeeBps: 0,
+    padding: 0,
     dynamicFee,
   };
   const positionNft = Keypair.generate();
@@ -372,6 +380,7 @@ export async function createDammV2BalancedPool(
     sqrtMinPrice: minSqrtPrice,
     sqrtMaxPrice: maxSqrtPrice,
     tokenAInfo: baseTokenInfo || undefined,
+    collectFeeMode,
   });
 
   console.log(
@@ -420,9 +429,18 @@ export async function createDammV2BalancedPool(
 
   const baseFeeParams: BaseFee = getBaseFeeParams(baseFee, quoteDecimals, activationType);
 
+  const compoundingFeeBps = collectFeeMode === 2 ? (poolFees.compoundingFeeBps ?? 0) : 0;
+  if (collectFeeMode === 2) {
+    console.log(
+      `- Compounding fee mode: ${compoundingFeeBps} bps of trading fees will be compounded back into pool liquidity`
+    );
+    console.log(`- Compounding pools use full price range (MIN_SQRT_PRICE to MAX_SQRT_PRICE)`);
+  }
+
   const poolFeesParams: PoolFeesParams = {
     baseFee: baseFeeParams,
-    padding: [],
+    compoundingFeeBps,
+    padding: 0,
     dynamicFee,
   };
 
@@ -557,6 +575,10 @@ export async function splitPosition(
           sqrtPrice: poolState.sqrtPrice,
           minSqrtPrice: poolState.sqrtMinPrice,
           maxSqrtPrice: poolState.sqrtMaxPrice,
+          collectFeeMode: poolState.collectFeeMode,
+          tokenAAmount: poolState.tokenAAmount,
+          tokenBAmount: poolState.tokenBAmount,
+          liquidity: poolState.liquidity,
         });
 
         return [
@@ -1086,6 +1108,10 @@ export async function addLiquidity(
     minSqrtPrice: poolState.sqrtMinPrice,
     maxSqrtPrice: poolState.sqrtMaxPrice,
     sqrtPrice: poolState.sqrtPrice,
+    collectFeeMode: poolState.collectFeeMode,
+    tokenAAmount: poolState.tokenAAmount,
+    tokenBAmount: poolState.tokenBAmount,
+    liquidity: poolState.liquidity,
   });
 
   console.log(`\n> Deposit quote:`);
@@ -1241,6 +1267,10 @@ export async function removeLiquidity(
           sqrtPrice: poolState.sqrtPrice,
           minSqrtPrice: poolState.sqrtMinPrice,
           maxSqrtPrice: poolState.sqrtMaxPrice,
+          collectFeeMode: poolState.collectFeeMode,
+          tokenAAmount: poolState.tokenAAmount,
+          tokenBAmount: poolState.tokenBAmount,
+          liquidity: poolState.liquidity,
         });
 
         return [
@@ -1325,6 +1355,10 @@ export async function removeLiquidity(
     sqrtPrice: poolState.sqrtPrice,
     minSqrtPrice: poolState.sqrtMinPrice,
     maxSqrtPrice: poolState.sqrtMaxPrice,
+    collectFeeMode: poolState.collectFeeMode,
+    tokenAAmount: poolState.tokenAAmount,
+    tokenBAmount: poolState.tokenBAmount,
+    liquidity: poolState.liquidity,
   });
 
   console.log(`\n> Withdraw quote:`);

--- a/studio/src/utils/types.ts
+++ b/studio/src/utils/types.ts
@@ -137,6 +137,7 @@ export interface DynamicAmmV2Config {
     baseFee: DammV2BaseFee;
     dynamicFeeEnabled: boolean;
     dynamicFeeConfig: DynamicFee | null;
+    compoundingFeeBps?: number;
   };
   collectFeeMode: number;
   activationType: number;


### PR DESCRIPTION
## Summary

Adds support for `CollectFeeMode.Compounding` (mode 2) in DAMM V2 pool creation, based on SDK changes in [damm-v2-sdk PR #101](https://github.com/MeteoraAg/damm-v2-sdk/pull/101).

Compounding pools use a constant-product (x·y=k) full-range model where a configurable percentage of trading fees are automatically compounded back into pool liquidity.

## Changes

### SDK Bump
- `@meteora-ag/cp-amm-sdk`: `^1.3.3` → `^1.3.7`

### Breaking API Changes Handled
The SDK v1.3.7 changed several function signatures:
- `PoolFeesParams`: added `compoundingFeeBps: number`, changed `padding: number[]` → `padding: number`
- `LiquidityDeltaParams`: added required `collectFeeMode`
- `GetDepositQuoteParams` / `GetWithdrawQuoteParams`: added required `collectFeeMode`, `tokenAAmount`, `tokenBAmount`, `liquidity`

### New Compounding Pool Support
- **`createDammV2OneSidedPool`**: Throws early if `collectFeeMode === 2` — compounding pools cannot be single-sided due to `DEAD_LIQUIDITY`
- **`createDammV2BalancedPool`**: Reads `poolFees.compoundingFeeBps` from config and passes it to `PoolFeesParams`; passes `collectFeeMode` to `getLiquidityDelta`
- All `getDepositQuote` / `getWithdrawQuote` calls updated with new required params from `poolState`

### Config & Types
- `DynamicAmmV2Config.poolFees`: added optional `compoundingFeeBps?: number`
- `CONFIG_SCHEMA`: `collectFeeMode` enum updated to `[0, 1, 2]`; `compoundingFeeBps` added to schema
- `damm_v2_config.jsonc`: updated `collectFeeMode` comment, added `compoundingFeeBps` example

## Usage

To create a compounding fee pool, set in `damm_v2_config.jsonc`:

```jsonc
{
  "dammV2Config": {
    "collectFeeMode": 2,
    "poolFees": {
      "compoundingFeeBps": 5000  // 50% of trading fees compound back into liquidity
    }
  }
}
```

Then run: `pnpm damm-v2-create-balanced-pool`

> ⚠️ `damm-v2-create-one-sided-pool` will error if `collectFeeMode: 2` is set.